### PR TITLE
Disable binary compression

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,12 +16,6 @@ builds:
       - windows
       - darwin
 
-upx:
-  - enabled: "{{ not .IsSnapshot }}"
-    compress: best
-    lzma: true
-    brute: true
-
 archives:
   - formats: ['tar.gz']
     # this name template makes the OS and Arch compatible with the results of `uname`.


### PR DESCRIPTION
Related: #13 

UPX can trigger false positives in anti-virus software